### PR TITLE
Secret can be with or w/o new-line character

### DIFF
--- a/src/ride/library/varnish/VarnishAdmin.php
+++ b/src/ride/library/varnish/VarnishAdmin.php
@@ -165,7 +165,7 @@ class VarnishAdmin implements VarnishServer {
 
             try {
                 $challenge = substr($banner, 0, 32);
-                $challengeResponse = hash('sha256', $challenge . "\n" . $this->secret . "\n" . $challenge . "\n");
+                $challengeResponse = hash('sha256', $challenge . "\n" . $this->secret . $challenge . "\n");
 
                 $banner = $this->execute('auth ' . $challengeResponse, $statusCode, 200);
             } catch (Exception $exception){


### PR DESCRIPTION
As per: https://github.com/all-ride/ride-lib-varnish/issues/2
